### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ wsgi-statsd documentation
 .. image:: https://api.travis-ci.org/paylogic/wsgi-statsd.png
    :target: https://travis-ci.org/paylogic/wsgi-statsd
 
-.. image:: https://pypip.in/v/wsgi-statsd/badge.png
+.. image:: https://img.shields.io/pypi/v/wsgi-statsd.svg
    :target: https://crate.io/packages/wsgi-statsd/
 
 .. image:: https://coveralls.io/repos/paylogic/wsgi-statsd/badge.svg?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20wsgi-statsd))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `wsgi-statsd`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.